### PR TITLE
fix: Add enhanced --help flag with detailed documentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,9 @@ use search::SearchMode;
 
 #[derive(Parser)]
 #[command(name = "treesearch")]
-#[command(about = "Tree-aware document search engine")]
+#[command(about = "Tree-aware document search engine", long_about = None)]
 #[command(version)]
+#[command(next_help_heading = "Commands")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -29,28 +30,36 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Quick search (auto-build index if needed)
+    ///
+    /// Examples:
+    ///   treesearch search "function" ./src
+    ///   treesearch search "README" . --mode tree -n 20
     Search {
-        /// Search query
+        /// Search query string
         query: String,
-        /// Path to search
+        /// Path to search (default: current directory)
         #[arg(default_value = ".")]
         path: PathBuf,
-        /// Search mode (auto, flat, tree)
+        /// Search mode: auto (default), flat, or tree
         #[arg(short, long, default_value = "auto")]
         mode: SearchModeConfig,
-        /// Database path
+        /// Database path (default: .treesearch.db in search path)
         #[arg(short, long)]
         db: Option<PathBuf>,
-        /// Maximum results
+        /// Maximum number of results to return
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
     },
-    /// Build index
+    /// Build search index for faster searches
+    ///
+    /// Examples:
+    ///   treesearch index ./src ./docs
+    ///   treesearch index . --max-files 50000
     Index {
         /// Paths to index
         #[arg(required = true)]
         paths: Vec<PathBuf>,
-        /// Database path
+        /// Database path (default: .treesearch.db in first path)
         #[arg(short, long)]
         db: Option<PathBuf>,
         /// Maximum nodes per document
@@ -60,7 +69,10 @@ enum Commands {
         #[arg(long, default_value = "10000")]
         max_files: usize,
     },
-    /// Show document info
+    /// Show document structure and metadata
+    ///
+    /// Examples:
+    ///   treesearch info README.md
     Info {
         /// Path to document
         path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,13 +34,14 @@ enum Commands {
     /// Examples:
     ///   treesearch search "function" ./src
     ///   treesearch search "README" . --mode tree -n 20
+    #[command(verbatim_doc_comment)]
     Search {
         /// Search query string
         query: String,
-        /// Path to search (default: current directory)
+        /// Path to search
         #[arg(default_value = ".")]
         path: PathBuf,
-        /// Search mode: auto (default), flat, or tree
+        /// Search mode: auto, flat, or tree
         #[arg(short, long, default_value = "auto")]
         mode: SearchModeConfig,
         /// Database path (default: .treesearch.db in search path)
@@ -55,6 +56,7 @@ enum Commands {
     /// Examples:
     ///   treesearch index ./src ./docs
     ///   treesearch index . --max-files 50000
+    #[command(verbatim_doc_comment)]
     Index {
         /// Paths to index
         #[arg(required = true)]
@@ -73,6 +75,7 @@ enum Commands {
     ///
     /// Examples:
     ///   treesearch info README.md
+    #[command(verbatim_doc_comment)]
     Info {
         /// Path to document
         path: PathBuf,


### PR DESCRIPTION
## Summary

Enhanced the CLI help experience by adding comprehensive documentation for all subcommands and their arguments. The CLI uses clap's derive API which automatically provides `--help` and `-h` flags for all commands and subcommands.

## Changes

- Added detailed help text for all subcommands (search, index, info)
- Included usage examples in help messages for each subcommand
- Improved argument descriptions with explanations of default values
- Enhanced main command help with better organization

## Testing

The changes are documentation-only and do not affect runtime behavior. The help text can be verified by running:
- `treesearch --help` - Shows main help with all subcommands
- `treesearch search --help` - Shows detailed help for search command
- `treesearch index --help` - Shows detailed help for index command
- `treesearch info --help` - Shows detailed help for info command

All help flags (`--help` and `-h`) are automatically provided by clap.

Fixes hu-qi/tree-search-rs#22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CLI help system with improved section organization and clearer command descriptions.
  * Added detailed documentation and example command invocations for Search, Index, and Info commands, making it easier to understand available functionality and proper usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->