### PR TITLE
fix: Add max-depth option

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -34,6 +34,12 @@ impl Indexer {
 
     /// Index a single file
     pub fn index_file(&mut self, path: &Path) -> Result<Option<Document>> {
+        self.index_file_with_depth(path, 0)
+    }
+
+    /// Index a single file with depth limit
+    /// If max_depth is 0, indexes all nodes (no limit)
+    pub fn index_file_with_depth(&mut self, path: &Path, max_depth: usize) -> Result<Option<Document>> {
         // Detect file type
         let ft = crate::pathutil::FileType::from_path(path);
 
@@ -52,7 +58,7 @@ impl Indexer {
 
         // Add to FTS index
         if let Some(fts) = &mut self.fts {
-            for node in doc.root.iter_dfs() {
+            for node in doc.root.iter_dfs_with_depth(max_depth) {
                 fts.add_document(
                     &node.node_id,
                     &doc.doc_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,9 @@ enum Commands {
         /// Maximum files to index
         #[arg(long, default_value = "10000")]
         max_files: usize,
+        /// Maximum depth to index (0 = no limit)
+        #[arg(long, default_value = "0")]
+        max_depth: usize,
     },
     /// Show document info
     Info {
@@ -80,8 +83,8 @@ fn main() -> Result<()> {
         Commands::Search { query, path, mode, db, limit, max_depth } => {
             search_cmd(query, path, mode, db, limit, max_depth)?;
         }
-        Commands::Index { paths, db, max_nodes, max_files } => {
-            index_cmd(paths, db, max_nodes, max_files)?;
+        Commands::Index { paths, db, max_nodes, max_files, max_depth } => {
+            index_cmd(paths, db, max_nodes, max_files, max_depth)?;
         }
         Commands::Info { path } => {
             info_cmd(path)?;
@@ -116,7 +119,11 @@ fn search_cmd(
     // Check if index exists
     let db_path = db.unwrap_or_else(|| path.join(".treesearch.db"));
 
-    if db_path.exists() {
+    // Skip index if max_depth is set (to ensure consistent behavior)
+    // When max_depth > 0, we need to parse documents fresh to apply depth filtering
+    let use_index = db_path.exists() && max_depth == 0;
+
+    if use_index {
         // Use existing index
         let index = FtsIndex::open(&db_path)?;
         let hits = index.search(&query, limit)?;
@@ -211,12 +218,16 @@ fn index_cmd(
     db: Option<PathBuf>,
     max_nodes: usize,
     max_files: usize,
+    max_depth: usize,
 ) -> Result<()> {
     use indexer::Indexer;
     use pathutil::{discover_files, DiscoveryOptions};
 
     println!("Building index...");
     println!("Paths: {:?}", paths);
+    if max_depth > 0 {
+        println!("Max depth: {}", max_depth);
+    }
 
     // Build config
     let mut config = Config::default();
@@ -251,7 +262,7 @@ fn index_cmd(
 
     let mut count = 0;
     for file in &all_files {
-        if let Some(doc) = indexer.index_file(file)? {
+        if let Some(doc) = indexer.index_file_with_depth(file, max_depth)? {
             count += 1;
             if count % 100 == 0 {
                 println!("Indexed {} documents...", count);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ enum Commands {
         /// Maximum results
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
+        /// Maximum depth to search (0 = no limit)
+        #[arg(long, default_value = "0")]
+        max_depth: usize,
     },
     /// Build index
     Index {
@@ -74,8 +77,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Search { query, path, mode, db, limit } => {
-            search_cmd(query, path, mode, db, limit)?;
+        Commands::Search { query, path, mode, db, limit, max_depth } => {
+            search_cmd(query, path, mode, db, limit, max_depth)?;
         }
         Commands::Index { paths, db, max_nodes, max_files } => {
             index_cmd(paths, db, max_nodes, max_files)?;
@@ -94,6 +97,7 @@ fn search_cmd(
     mode: SearchModeConfig,
     db: Option<PathBuf>,
     limit: usize,
+    max_depth: usize,
 ) -> Result<()> {
     use fts::FtsIndex;
     use search::SearchEngine;
@@ -168,7 +172,7 @@ fn search_cmd(
         index.begin_write()?;
 
         for doc in &documents {
-            for node in doc.root.iter_dfs() {
+            for node in doc.root.iter_dfs_with_depth(max_depth) {
                 index.add_document(
                     &node.node_id,
                     &doc.doc_id,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -101,6 +101,12 @@ impl TreeNode {
     pub fn iter_dfs(&self) -> TreeNodeIter {
         TreeNodeIter::new(self)
     }
+
+    /// Iterate over all nodes in DFS order with depth limit
+    /// If max_depth is 0, iterates all nodes (no limit)
+    pub fn iter_dfs_with_depth(&self, max_depth: usize) -> TreeNodeIterWithDepth {
+        TreeNodeIterWithDepth::new(self, max_depth)
+    }
 }
 
 /// DFS iterator for tree nodes
@@ -122,6 +128,39 @@ impl<'a> Iterator for TreeNodeIter<'a> {
         // Push children in reverse order for correct DFS order
         for child in node.children.iter().rev() {
             self.stack.push(child);
+        }
+        Some(node)
+    }
+}
+
+/// DFS iterator for tree nodes with depth limit
+pub struct TreeNodeIterWithDepth<'a> {
+    stack: Vec<(&'a TreeNode, usize)>, // (node, depth)
+    max_depth: usize,
+}
+
+impl<'a> TreeNodeIterWithDepth<'a> {
+    fn new(root: &'a TreeNode, max_depth: usize) -> Self {
+        Self { 
+            stack: vec![(root, 0)],
+            max_depth,
+        }
+    }
+}
+
+impl<'a> Iterator for TreeNodeIterWithDepth<'a> {
+    type Item = &'a TreeNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (node, depth) = self.stack.pop()?;
+        
+        // Push children in reverse order for correct DFS order
+        // Only push children if we haven't reached max_depth
+        // (max_depth == 0 means no limit)
+        if self.max_depth == 0 || depth < self.max_depth {
+            for child in node.children.iter().rev() {
+                self.stack.push((child, depth + 1));
+            }
         }
         Some(node)
     }
@@ -210,5 +249,26 @@ mod tests {
 
         let ids: Vec<_> = root.iter_dfs().map(|n| n.node_id.as_str()).collect();
         assert_eq!(ids, vec!["root", "child1", "child2"]);
+    }
+
+    #[test]
+    fn test_dfs_iteration_with_depth_limit() {
+        let mut root = TreeNode::new("root", "Root");
+        let mut child1 = TreeNode::new("child1", "Child 1");
+        child1.children.push(TreeNode::new("grandchild", "Grandchild"));
+        root.children.push(child1);
+        root.children.push(TreeNode::new("child2", "Child 2"));
+
+        // No limit (max_depth = 0)
+        let ids: Vec<_> = root.iter_dfs_with_depth(0).map(|n| n.node_id.as_str()).collect();
+        assert_eq!(ids, vec!["root", "child1", "grandchild", "child2"]);
+
+        // Limit to depth 1 (root + children, no grandchildren)
+        let ids: Vec<_> = root.iter_dfs_with_depth(1).map(|n| n.node_id.as_str()).collect();
+        assert_eq!(ids, vec!["root", "child1", "child2"]);
+
+        // Limit to depth 2 (all nodes)
+        let ids: Vec<_> = root.iter_dfs_with_depth(2).map(|n| n.node_id.as_str()).collect();
+        assert_eq!(ids, vec!["root", "child1", "grandchild", "child2"]);
     }
 }


### PR DESCRIPTION
## Summary

Adds --max-depth parameter to limit search depth.

## Changes

- Added --max-depth CLI argument to Search command
- Added iter_dfs_with_depth method to TreeNode for depth-limited iteration
- Depth limit of 0 means no limit (default behavior)
- Added comprehensive tests for depth-limited iteration

## Implementation Details

The implementation adds a new iterator `TreeNodeIterWithDepth` that tracks the depth of each node during DFS traversal. When max_depth is set to a non-zero value, the iterator stops traversing deeper once that depth is reached.

## Testing

Added unit tests to verify:
- No limit (max_depth = 0) includes all nodes
- Depth limit correctly stops at specified depth
- Multiple depth levels work correctly

Fixes hu-qi/tree-search-rs#24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable depth limit to Search and Index commands (default: unlimited). When set, searches/indexing apply the depth filter and use on-the-fly indexing to honor the limit; the chosen depth is displayed during indexing.

* **Tests**
  * Added unit tests validating depth-limited traversal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->