### PR TITLE
fix: Add --exclude parameter for excluding file patterns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,16 @@ fn search_cmd(
     if db_path.exists() {
         // Use existing index
         let index = FtsIndex::open(&db_path)?;
-        let hits = index.search(&query, limit)?;
+        let mut hits = index.search(&query, limit)?;
+
+        // Apply exclusion filters to hits
+        if !excludes.is_empty() {
+            use pathutil::matches_pattern;
+            hits.retain(|hit| {
+                let path = PathBuf::from(&hit.title);
+                !excludes.iter().any(|pattern| matches_pattern(&path, pattern))
+            });
+        }
 
         if hits.is_empty() {
             println!("No results found.");
@@ -144,9 +153,7 @@ fn search_cmd(
 
         // Discover files
         let mut options = DiscoveryOptions::default();
-        if !excludes.is_empty() {
-            options.exclude = excludes;
-        }
+        options.exclude.extend(excludes);
         let files = discover_files(&path, &options)?;
 
         if files.is_empty() {
@@ -238,9 +245,7 @@ fn index_cmd(
 
     // Discover files
     let mut options = DiscoveryOptions::default();
-    if !excludes.is_empty() {
-        options.exclude = excludes;
-    }
+    options.exclude.extend(excludes);
     let mut all_files = Vec::new();
 
     for path in &paths {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ enum Commands {
         /// Maximum results
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
+        /// Exclude patterns (glob)
+        #[arg(short, long = "exclude")]
+        excludes: Vec<String>,
     },
     /// Build index
     Index {
@@ -59,6 +62,9 @@ enum Commands {
         /// Maximum files to index
         #[arg(long, default_value = "10000")]
         max_files: usize,
+        /// Exclude patterns (glob)
+        #[arg(short, long = "exclude")]
+        excludes: Vec<String>,
     },
     /// Show document info
     Info {
@@ -74,11 +80,11 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Search { query, path, mode, db, limit } => {
-            search_cmd(query, path, mode, db, limit)?;
+        Commands::Search { query, path, mode, db, limit, excludes } => {
+            search_cmd(query, path, mode, db, limit, excludes)?;
         }
-        Commands::Index { paths, db, max_nodes, max_files } => {
-            index_cmd(paths, db, max_nodes, max_files)?;
+        Commands::Index { paths, db, max_nodes, max_files, excludes } => {
+            index_cmd(paths, db, max_nodes, max_files, excludes)?;
         }
         Commands::Info { path } => {
             info_cmd(path)?;
@@ -94,6 +100,7 @@ fn search_cmd(
     mode: SearchModeConfig,
     db: Option<PathBuf>,
     limit: usize,
+    excludes: Vec<String>,
 ) -> Result<()> {
     use fts::FtsIndex;
     use search::SearchEngine;
@@ -136,7 +143,10 @@ fn search_cmd(
         println!("No index found. Performing quick search (may be slow)...");
 
         // Discover files
-        let options = DiscoveryOptions::default();
+        let mut options = DiscoveryOptions::default();
+        if !excludes.is_empty() {
+            options.exclude = excludes;
+        }
         let files = discover_files(&path, &options)?;
 
         if files.is_empty() {
@@ -207,6 +217,7 @@ fn index_cmd(
     db: Option<PathBuf>,
     max_nodes: usize,
     max_files: usize,
+    excludes: Vec<String>,
 ) -> Result<()> {
     use indexer::Indexer;
     use pathutil::{discover_files, DiscoveryOptions};
@@ -226,7 +237,10 @@ fn index_cmd(
     }
 
     // Discover files
-    let options = DiscoveryOptions::default();
+    let mut options = DiscoveryOptions::default();
+    if !excludes.is_empty() {
+        options.exclude = excludes;
+    }
     let mut all_files = Vec::new();
 
     for path in &paths {

--- a/src/pathutil.rs
+++ b/src/pathutil.rs
@@ -122,6 +122,8 @@ impl Default for DiscoveryOptions {
 /// 2. Built-in .gitignore support
 /// 3. Optimized filtering
 pub fn discover_files(root: &Path, options: &DiscoveryOptions) -> Result<Vec<PathBuf>> {
+    use ignore::overrides::Override;
+
     let mut files = Vec::new();
 
     let mut builder = WalkBuilder::new(root);
@@ -135,9 +137,14 @@ pub fn discover_files(root: &Path, options: &DiscoveryOptions) -> Result<Vec<Pat
         .hidden(false)  // Include hidden files
         .threads(num_cpus::get());  // Parallel traversal
 
-    // Add custom ignore patterns
-    for pattern in &options.exclude {
-        builder.add_ignore(pattern);
+    // Build override for custom exclusion patterns
+    if !options.exclude.is_empty() {
+        let mut override_builder = ignore::overrides::OverrideBuilder::new(root);
+        for pattern in &options.exclude {
+            // Add exclusion pattern with '!' prefix to exclude
+            override_builder.add(&format!("!{}", pattern))?;
+        }
+        builder.overrides(override_builder.build()?);
     }
 
     for result in builder.build() {


### PR DESCRIPTION
## Summary

This PR adds support for the `--exclude` parameter to both the `search` and `index` commands, allowing users to specify custom glob patterns for excluding files from discovery.

## Changes

- Added `--exclude` parameter to the `search` command
- Added `--exclude` parameter to the `index` command
- Updated `search_cmd` and `index_cmd` functions to accept and use exclude patterns
- Exclude patterns override the default exclusion patterns when provided

## Usage Examples

```bash
# Exclude node_modules and target directories
 treesearch search "query" . --exclude "**/node_modules/**" --exclude "**/target/**"

# Exclude specific file patterns
 treesearch index . --exclude "**/*.test.rs" --exclude "**/fixtures/**"
```

## Testing

The changes were manually verified by checking the code structure. The implementation leverages the existing `DiscoveryOptions` infrastructure which already supports exclude patterns through the `ignore` crate.

Fixes hu-qi/tree-search-rs#18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --exclude option to Search and Index commands to omit matching paths from discovery and indexing.
* **Behavior Changes**
  * Search results from an existing index are now filtered to remove excluded paths.
  * Quick searches and index builds now apply exclusion patterns to file discovery using improved ignore handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->