### PR TITLE
fix: Add --config parameter support for configuration files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tantivy = "0.22"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Logging
 tracing = "0.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,21 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Load configuration from a file (TOML or JSON)
+    pub fn from_file(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let content = std::fs::read_to_string(path)?;
+        
+        // Determine format from extension
+        let config = if path.extension().map_or(false, |ext| ext == "json") {
+            serde_json::from_str(&content)?
+        } else {
+            // Default to TOML
+            toml::from_str(&content)?
+        };
+        
+        Ok(config)
+    }
+
     /// Create config with overrides from environment variables
     pub fn from_env() -> Self {
         let mut config = Self::default();
@@ -67,6 +82,18 @@ impl Config {
         let mut config = Self::from_env();
         config.db_path = project_dir.into().join(".treesearch.db");
         config
+    }
+
+    /// Merge with another config, where self takes precedence (for CLI overrides)
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            db_path: other.db_path,
+            max_nodes_per_doc: other.max_nodes_per_doc,
+            max_files: other.max_files,
+            search_mode: other.search_mode,
+            add_description: other.add_description,
+            index_dir: other.index_dir,
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ use search::SearchMode;
 #[command(about = "Tree-aware document search engine")]
 #[command(version)]
 struct Cli {
+    /// Configuration file path (TOML or JSON)
+    #[arg(short, long, global = true)]
+    config: Option<PathBuf>,
+    
     #[command(subcommand)]
     command: Commands,
 }
@@ -73,12 +77,20 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    // Load config from file if provided
+    let file_config = if let Some(config_path) = &cli.config {
+        Some(Config::from_file(config_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load config file: {}", e))?)
+    } else {
+        None
+    };
+
     match cli.command {
         Commands::Search { query, path, mode, db, limit } => {
-            search_cmd(query, path, mode, db, limit)?;
+            search_cmd(query, path, mode, db, limit, file_config)?;
         }
         Commands::Index { paths, db, max_nodes, max_files } => {
-            index_cmd(paths, db, max_nodes, max_files)?;
+            index_cmd(paths, db, max_nodes, max_files, file_config)?;
         }
         Commands::Info { path } => {
             info_cmd(path)?;
@@ -94,6 +106,7 @@ fn search_cmd(
     mode: SearchModeConfig,
     db: Option<PathBuf>,
     limit: usize,
+    file_config: Option<Config>,
 ) -> Result<()> {
     use fts::FtsIndex;
     use search::SearchEngine;
@@ -109,8 +122,13 @@ fn search_cmd(
         SearchModeConfig::Tree => SearchMode::Tree,
     };
 
-    // Check if index exists
-    let db_path = db.unwrap_or_else(|| path.join(".treesearch.db"));
+    // Determine db_path: CLI > config file > default
+    let db_path = db.unwrap_or_else(|| {
+        file_config
+            .as_ref()
+            .map(|c| c.db_path.clone())
+            .unwrap_or_else(|| path.join(".treesearch.db"))
+    });
 
     if db_path.exists() {
         // Use existing index
@@ -207,6 +225,7 @@ fn index_cmd(
     db: Option<PathBuf>,
     max_nodes: usize,
     max_files: usize,
+    file_config: Option<Config>,
 ) -> Result<()> {
     use indexer::Indexer;
     use pathutil::{discover_files, DiscoveryOptions};
@@ -214,15 +233,20 @@ fn index_cmd(
     println!("Building index...");
     println!("Paths: {:?}", paths);
 
-    // Build config
-    let mut config = Config::default();
+    // Build config: start with file config or default
+    let mut config = file_config.unwrap_or_default();
+    
+    // Apply CLI overrides
     config.max_nodes_per_doc = max_nodes;
     config.max_files = max_files;
 
     if let Some(db_path) = db {
         config.db_path = db_path;
-    } else if let Some(first_path) = paths.first() {
-        config.db_path = first_path.join(".treesearch.db");
+    } else if config.db_path == PathBuf::from(".treesearch.db") {
+        // Only use default if not set by config file
+        if let Some(first_path) = paths.first() {
+            config.db_path = first_path.join(".treesearch.db");
+        }
     }
 
     // Discover files


### PR DESCRIPTION
## Summary

This PR adds support for loading configuration from TOML or JSON files via a new `--config` CLI parameter. The configuration file settings can be overridden by command-line arguments.

## Changes

- Added `toml` dependency to `Cargo.toml` for TOML config file parsing
- Added `Config::from_file()` method to load config from TOML or JSON files
- Added `--config` (-c) global argument to CLI
- Updated `search` and `index` commands to use config file when provided
- CLI arguments take precedence over config file settings

## Testing

The code compiles successfully. Manual testing would involve:
1. Creating a config file (e.g., `config.toml`)
2. Running `treesearch --config config.toml search "query"`
3. Verifying that CLI arguments override config file values

Fixes hu-qi/tree-search-rs#7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--config` global option to load configuration from files in TOML or JSON format
  * Configuration settings now control database paths and index behavior
  * CLI arguments take precedence over configuration file values and built-in defaults
  * Configuration file loading failures are reported with clear error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->