### PR TITLE
fix: Add --sort option for result sorting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,3 +100,37 @@ impl std::str::FromStr for SearchModeConfig {
         }
     }
 }
+
+/// Sort by option for search results
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SortBy {
+    /// No sorting (relevance order from search engine)
+    None,
+    /// Sort by title/name (alphabetical)
+    Name,
+    /// Sort by relevance score (highest first)
+    Score,
+}
+
+impl std::fmt::Display for SortBy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Name => write!(f, "name"),
+            Self::Score => write!(f, "score"),
+        }
+    }
+}
+
+impl std::str::FromStr for SortBy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "none" => Ok(Self::None),
+            "name" => Ok(Self::Name),
+            "score" => Ok(Self::Score),
+            _ => Err(format!("Invalid sort option: {}. Valid options: none, name, score", s)),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod pathutil;
 mod heuristics;
 mod parsers;
 
-use config::{Config, SearchModeConfig};
+use config::{Config, SearchModeConfig, SortBy};
 use search::SearchMode;
 
 #[derive(Parser)]
@@ -44,6 +44,9 @@ enum Commands {
         /// Maximum results
         #[arg(short = 'n', long, default_value = "10")]
         limit: usize,
+        /// Sort results by (none, name, score)
+        #[arg(long, default_value = "none")]
+        sort: SortBy,
     },
     /// Build index
     Index {
@@ -74,8 +77,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Search { query, path, mode, db, limit } => {
-            search_cmd(query, path, mode, db, limit)?;
+        Commands::Search { query, path, mode, db, limit, sort } => {
+            search_cmd(query, path, mode, db, limit, sort)?;
         }
         Commands::Index { paths, db, max_nodes, max_files } => {
             index_cmd(paths, db, max_nodes, max_files)?;
@@ -94,6 +97,7 @@ fn search_cmd(
     mode: SearchModeConfig,
     db: Option<PathBuf>,
     limit: usize,
+    sort: SortBy,
 ) -> Result<()> {
     use fts::FtsIndex;
     use search::SearchEngine;
@@ -115,7 +119,10 @@ fn search_cmd(
     if db_path.exists() {
         // Use existing index
         let index = FtsIndex::open(&db_path)?;
-        let hits = index.search(&query, limit)?;
+        let mut hits = index.search(&query, limit)?;
+
+        // Apply sorting
+        apply_sort(&mut hits, sort);
 
         if hits.is_empty() {
             println!("No results found.");
@@ -185,7 +192,10 @@ fn search_cmd(
         index.reload()?;
 
         // Search
-        let hits = index.search(&query, limit)?;
+        let mut hits = index.search(&query, limit)?;
+
+        // Apply sorting
+        apply_sort(&mut hits, sort);
 
         if hits.is_empty() {
             println!("No results found.");
@@ -200,6 +210,25 @@ fn search_cmd(
     }
 
     Ok(())
+}
+
+/// Apply sorting to search hits
+fn apply_sort(hits: &mut [fts::SearchHit], sort: SortBy) {
+    use fts::SearchHit;
+    
+    match sort {
+        SortBy::None => {
+            // No sorting, keep relevance order from search engine
+        }
+        SortBy::Name => {
+            // Sort by title alphabetically
+            hits.sort_by(|a, b| a.title.cmp(&b.title));
+        }
+        SortBy::Score => {
+            // Sort by score (highest first)
+            hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        }
+    }
 }
 
 fn index_cmd(


### PR DESCRIPTION
## Summary

Add --sort parameter to the search command to allow sorting search results by different criteria.

## Changes

- Added SortBy enum in config.rs with variants: None, Name, Score
- Added --sort argument to the Search command in main.rs
- Added apply_sort helper function to sort search hits
- Applied sorting in both search paths (with index and without index)

## Sorting Options

- `none` (default): No sorting, keeps relevance order from search engine
- `name`: Sort by title alphabetically
- `score`: Sort by relevance score (highest first)

## Testing

Code changes compile successfully. The implementation follows existing patterns (similar to SearchModeConfig) and integrates cleanly with the existing search command structure.

Fixes hu-qi/tree-search-rs#29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search result sorting. Users can now sort search results by relevance score, alphabetically by name, or maintain the default search engine order. This new sorting capability is accessible through the command-line interface and defaults to the original ordering when no sort option is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->