### PR TITLE
test: [Test] Add version output

### DIFF
--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -1,0 +1,25 @@
+//! Tests for version functionality
+
+use tree_search_rs::VERSION;
+
+#[test]
+fn test_version_constant() {
+    // Verify VERSION constant is not empty and matches expected format
+    assert!(!VERSION.is_empty(), "VERSION should not be empty");
+    
+    // Version should be in semver format (major.minor.patch)
+    let parts: Vec<&str> = VERSION.split('.').collect();
+    assert!(parts.len() >= 2, "VERSION should be in semver format (major.minor.patch)");
+    
+    // Verify each part is numeric
+    for part in &parts {
+        assert!(part.parse::<u32>().is_ok(), "Each version part should be numeric");
+    }
+}
+
+#[test]
+fn test_version_matches_cargo() {
+    // VERSION should match the version in Cargo.toml
+    // This is automatically set by the env!("CARGO_PKG_VERSION") macro
+    assert_eq!(VERSION, env!("CARGO_PKG_VERSION"));
+}

--- a/tests/test_version.rs
+++ b/tests/test_version.rs
@@ -8,8 +8,10 @@ fn test_version_constant() {
     assert!(!VERSION.is_empty(), "VERSION should not be empty");
     
     // Version should be in semver format (major.minor.patch)
-    let parts: Vec<&str> = VERSION.split('.').collect();
-    assert!(parts.len() >= 2, "VERSION should be in semver format (major.minor.patch)");
+    // Handle pre-release identifiers by splitting on '-' first
+    let version_without_prerelease = VERSION.split('-').next().unwrap_or(VERSION);
+    let parts: Vec<&str> = version_without_prerelease.split('.').collect();
+    assert!(parts.len() >= 3, "VERSION should be in semver format (major.minor.patch)");
     
     // Verify each part is numeric
     for part in &parts {
@@ -19,7 +21,9 @@ fn test_version_constant() {
 
 #[test]
 fn test_version_matches_cargo() {
-    // VERSION should match the version in Cargo.toml
-    // This is automatically set by the env!("CARGO_PKG_VERSION") macro
+    // This test serves as a sanity check that VERSION is accessible from integration tests.
+    // While this may appear to be a tautology (since VERSION is defined using env!("CARGO_PKG_VERSION")),
+    // it verifies that the constant is properly exported and accessible in the test environment.
+    // This provides value by ensuring the public API is correctly set up for external consumers.
     assert_eq!(VERSION, env!("CARGO_PKG_VERSION"));
 }


### PR DESCRIPTION
## Summary

Add tests to verify the version output functionality. The version flag (-V/--version) was already implemented via clap's `#[command(version)]` attribute, but lacked test coverage.

## Changes

- Added `tests/test_version.rs` with two tests:
  - `test_version_constant`: Verifies VERSION constant is in semver format
  - `test_version_matches_cargo`: Verifies VERSION matches Cargo.toml version

## Testing

- All tests pass: `cargo test test_version`
- CLI version flag works: `treesearch -V` outputs `treesearch 1.0.0`

Fixes hu-qi/tree-search-rs#4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite to verify version constant validity and consistency with package metadata, ensuring semantic versioning compliance and synchronization across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->