### PR TITLE
fix: add verbose flag (-v) for detailed output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ use search::SearchMode;
 #[command(about = "Tree-aware document search engine")]
 #[command(version)]
 struct Cli {
+    /// Enable verbose output
+    #[arg(short, long, global = true)]
+    verbose: bool,
+    
     #[command(subcommand)]
     command: Commands,
 }
@@ -68,20 +72,28 @@ enum Commands {
 }
 
 fn main() -> Result<()> {
-    // Initialize logging
-    tracing_subscriber::fmt::init();
-
     let cli = Cli::parse();
+
+    // Initialize logging based on verbose flag
+    if cli.verbose {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .init();
+    }
 
     match cli.command {
         Commands::Search { query, path, mode, db, limit } => {
-            search_cmd(query, path, mode, db, limit)?;
+            search_cmd(query, path, mode, db, limit, cli.verbose)?;
         }
         Commands::Index { paths, db, max_nodes, max_files } => {
-            index_cmd(paths, db, max_nodes, max_files)?;
+            index_cmd(paths, db, max_nodes, max_files, cli.verbose)?;
         }
         Commands::Info { path } => {
-            info_cmd(path)?;
+            info_cmd(path, cli.verbose)?;
         }
     }
 
@@ -94,13 +106,17 @@ fn search_cmd(
     mode: SearchModeConfig,
     db: Option<PathBuf>,
     limit: usize,
+    verbose: bool,
 ) -> Result<()> {
     use fts::FtsIndex;
     use search::SearchEngine;
 
     println!("Searching for: {}", query);
-    println!("Path: {:?}", path);
-    println!("Mode: {}", mode);
+    if verbose {
+        println!("Path: {:?}", path);
+        println!("Mode: {}", mode);
+        println!("Limit: {}", limit);
+    }
 
     // Determine search mode
     let search_mode = match mode {
@@ -112,9 +128,18 @@ fn search_cmd(
     // Check if index exists
     let db_path = db.unwrap_or_else(|| path.join(".treesearch.db"));
 
+    if verbose {
+        println!("Database path: {:?}", db_path);
+    }
+
     if db_path.exists() {
         // Use existing index
         let index = FtsIndex::open(&db_path)?;
+        
+        if verbose {
+            println!("Using existing index at {:?}", db_path);
+        }
+        
         let hits = index.search(&query, limit)?;
 
         if hits.is_empty() {
@@ -124,6 +149,9 @@ fn search_cmd(
             for (i, hit) in hits.iter().enumerate() {
                 println!("{}. {} (score: {:.3})", i + 1, hit.title, hit.score);
                 println!("   Node: {}", hit.node_id);
+                if verbose {
+                    println!("   Document: {}", hit.doc_id);
+                }
                 println!();
             }
         }
@@ -144,6 +172,10 @@ fn search_cmd(
             return Ok(());
         }
 
+        if verbose {
+            println!("Discovered {} files", files.len());
+        }
+
         println!("Found {} files, searching...", files.len());
 
         // Parse documents
@@ -156,6 +188,9 @@ fn search_cmd(
                 if let Ok(content) = std::fs::read_to_string(file) {
                     if let Ok(doc) = parser.parse(&content, file) {
                         documents.push(doc);
+                        if verbose {
+                            tracing::debug!("Parsed: {:?}", file);
+                        }
                     }
                 }
             }
@@ -166,6 +201,10 @@ fn search_cmd(
         // Create in-memory index
         let mut index = FtsIndex::create_in_memory()?;
         index.begin_write()?;
+
+        if verbose {
+            println!("Building in-memory index...");
+        }
 
         for doc in &documents {
             for node in doc.root.iter_dfs() {
@@ -194,6 +233,9 @@ fn search_cmd(
             for (i, hit) in hits.iter().enumerate() {
                 println!("{}. {} (score: {:.3})", i + 1, hit.title, hit.score);
                 println!("   Node: {}", hit.node_id);
+                if verbose {
+                    println!("   Document: {}", hit.doc_id);
+                }
                 println!();
             }
         }
@@ -207,12 +249,17 @@ fn index_cmd(
     db: Option<PathBuf>,
     max_nodes: usize,
     max_files: usize,
+    verbose: bool,
 ) -> Result<()> {
     use indexer::Indexer;
     use pathutil::{discover_files, DiscoveryOptions};
 
     println!("Building index...");
-    println!("Paths: {:?}", paths);
+    if verbose {
+        println!("Paths: {:?}", paths);
+        println!("Max nodes per doc: {}", max_nodes);
+        println!("Max files: {}", max_files);
+    }
 
     // Build config
     let mut config = Config::default();
@@ -223,6 +270,10 @@ fn index_cmd(
         config.db_path = db_path;
     } else if let Some(first_path) = paths.first() {
         config.db_path = first_path.join(".treesearch.db");
+    }
+
+    if verbose {
+        println!("Database path: {:?}", config.db_path);
     }
 
     // Discover files
@@ -249,7 +300,9 @@ fn index_cmd(
     for file in &all_files {
         if let Some(doc) = indexer.index_file(file)? {
             count += 1;
-            if count % 100 == 0 {
+            if verbose {
+                println!("[{}/{}] Indexed: {:?}", count, all_files.len(), file);
+            } else if count % 100 == 0 {
                 println!("Indexed {} documents...", count);
             }
         }
@@ -264,7 +317,7 @@ fn index_cmd(
     Ok(())
 }
 
-fn info_cmd(path: PathBuf) -> Result<()> {
+fn info_cmd(path: PathBuf, verbose: bool) -> Result<()> {
     use pathutil::FileType;
     use parsers::ParserRegistry;
 
@@ -291,6 +344,17 @@ fn info_cmd(path: PathBuf) -> Result<()> {
         println!("  Tree depth: {}", doc.tree_depth());
         println!("  Node count: {}", doc.count_nodes());
         println!("  Tree benefit: {}", doc.tree_benefit());
+        
+        if verbose {
+            println!("\nVerbose info:");
+            println!("  File size: {} bytes", content.len());
+            // Count nodes by type
+            let mut node_types = std::collections::HashMap::new();
+            for node in doc.root.iter_dfs() {
+                *node_types.entry(node.node_type.clone()).or_insert(0) += 1;
+            }
+            println!("  Node types: {:?}", node_types);
+        }
     } else {
         println!("No parser available for this file type.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,15 +75,14 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logging based on verbose flag
-    if cli.verbose {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .init();
+    let log_level = if cli.verbose {
+        tracing::Level::DEBUG
     } else {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .init();
-    }
+        tracing::Level::INFO
+    };
+    tracing_subscriber::fmt()
+        .with_max_level(log_level)
+        .init();
 
     match cli.command {
         Commands::Search { query, path, mode, db, limit } => {
@@ -188,9 +187,7 @@ fn search_cmd(
                 if let Ok(content) = std::fs::read_to_string(file) {
                     if let Ok(doc) = parser.parse(&content, file) {
                         documents.push(doc);
-                        if verbose {
-                            tracing::debug!("Parsed: {:?}", file);
-                        }
+                        tracing::debug!("Parsed: {:?}", file);
                     }
                 }
             }
@@ -348,10 +345,19 @@ fn info_cmd(path: PathBuf, verbose: bool) -> Result<()> {
         if verbose {
             println!("\nVerbose info:");
             println!("  File size: {} bytes", content.len());
-            // Count nodes by type
+            // Count nodes by type (computed from content fields)
             let mut node_types = std::collections::HashMap::new();
             for node in doc.root.iter_dfs() {
-                *node_types.entry(node.node_type.clone()).or_insert(0) += 1;
+                let node_kind = if node.code.is_some() {
+                    "code"
+                } else if node.front_matter.is_some() {
+                    "front_matter"
+                } else if !node.text.is_empty() {
+                    "text"
+                } else {
+                    "structural"
+                };
+                *node_types.entry(node_kind).or_insert(0) += 1;
             }
             println!("  Node types: {:?}", node_types);
         }


### PR DESCRIPTION
## Summary

Add a global `-v/--verbose` flag to enable detailed output across all CLI commands. When enabled, the flag sets the logging level to DEBUG and shows additional information such as paths, configuration details, and per-file progress.

## Changes

- Added global `-v/--verbose` flag to the CLI struct using clap
- Updated logging initialization to use DEBUG level when verbose is enabled, INFO otherwise
- Enhanced `search_cmd` to show path, mode, limit, database path, and document IDs in verbose mode
- Enhanced `index_cmd` to show paths, config details, and per-file indexing progress in verbose mode
- Enhanced `info_cmd` to show file size and node type distribution in verbose mode

## Testing

The code compiles successfully and follows the existing code patterns. Manual testing recommended:

```bash
# Test verbose flag with search
treesearch -v search "query" /path

# Test verbose flag with index
treesearch -v index /path

# Test verbose flag with info
treesearch -v info /path/to/file.md
```

Fixes hu-qi/tree-search-rs#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --verbose / -v CLI flag that enables enhanced logging and diagnostics across all commands (search, index, info). When enabled, displays extra runtime details (paths, parameters, resolved DB path), per-file processing and progress, discovered item counts, per-hit IDs, and debug-level tracing; default behavior and output remain unchanged when not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->