### PR TITLE
fix: enable manual testing of simplified workflow

### DIFF
--- a/.github/workflows/ai-issue.yml
+++ b/.github/workflows/ai-issue.yml
@@ -3,6 +3,12 @@ name: AI Issue Handler
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      test_issue_number:
+        description: 'Issue number to test with'
+        required: false
+        default: ''
 
 jobs:
   handle:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` event to the AI Issue Handler workflow to enable manual testing of the simplified workflow. This allows verification without needing to create a new issue.

## Changes

- Added `workflow_dispatch` event trigger to `.github/workflows/ai-issue.yml`
- Added optional `test_issue_number` input for testing with specific issues
- Enables manual workflow triggering via GitHub Actions UI or API

## Testing

- YAML syntax validated successfully
- Workflow can now be manually triggered from the Actions tab
- No changes to existing issue-triggered workflow behavior

Fixes hu-qi/tree-search-rs#8