### PR TITLE
fix: improve error message for info command when file not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,10 +268,21 @@ fn info_cmd(path: PathBuf) -> Result<()> {
     use pathutil::FileType;
     use parsers::ParserRegistry;
 
-    println!("File: {:?}", path);
+    // Check if file exists and get absolute path
+    let abs_path = path.canonicalize()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "File not found: '{}'\nError: {}\nCurrent directory: {:?}",
+                path.display(),
+                e,
+                std::env::current_dir().unwrap_or_default()
+            )
+        })?;
+
+    println!("File: {:?}", abs_path);
 
     // Detect file type
-    let ft = FileType::from_path(&path);
+    let ft = FileType::from_path(&abs_path);
     println!("Type: {:?}", ft);
     println!("Tree benefit: {}", ft.tree_benefit());
 
@@ -281,8 +292,8 @@ fn info_cmd(path: PathBuf) -> Result<()> {
         println!("Parser: {}", parser.name());
 
         // Parse document
-        let content = std::fs::read_to_string(&path)?;
-        let doc = parser.parse(&content, &path)?;
+        let content = std::fs::read_to_string(&abs_path)?;
+        let doc = parser.parse(&content, &abs_path)?;
 
         println!("\nDocument info:");
         println!("  ID: {}", doc.doc_id);


### PR DESCRIPTION
## Summary

This PR improves the error handling in the `info` command to provide a clearer error message when a file is not found. Instead of showing a generic OS error (e.g., "系统找不到指定的文件。 (os error 2)" on Chinese Windows), it now shows:

- The file path that was not found
- The original error message
- The current working directory

This helps users understand where the command is looking for the file and why it might not be found.

## Changes

- Modified `info_cmd` function in `src/main.rs` to:
  - Use `canonicalize()` to check if file exists and get absolute path
  - Provide detailed error message with file path, error, and current directory
  - Use absolute path throughout the function for consistency

## Testing

The fix was tested by verifying the code compiles correctly. The error handling logic is straightforward and uses standard Rust stdlib functions.

Fixes hu-qi/tree-search-rs#10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The info command now resolves paths to their absolute canonical form and displays these resolved paths instead of the original input.
  * Error messages are now enriched with additional context information when path operations fail, providing better diagnostics for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->